### PR TITLE
Replace responsible browsing context

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -15,8 +15,6 @@ spec:infra; type:dfn; for:/; text:list
 spec:infra; type:dfn; for:list; text:append
 spec:infra; type:dfn; for:set; text:append
 spec:html; type:dfn; for:/; text:origin
-spec:html; type:dfn; for:environment settings object; text:global object
-spec:html; type:dfn; for:/; text:browsing context
 spec:fetch; type:dfn; for:/; text:fetch
 spec:fetch; type:dfn; for:Request; text:request
 spec:fetch; type:dfn; text:client
@@ -148,7 +146,7 @@ When asked to <dfn abstract-op>initialize the Client Hints set</dfn> with |setti
 1. Let |clientHintsSet| be the result of running [=retrieve the client hints set=] with |settingsObject|'s [=environment settings object/origin=].
 2. For each |hint| in |clientHintsSet|, [=set/append=] |hint| to |settingsObject|'s [=environment settings object/client hints set=].
 3. If the result of executing [$Is an environment settings object contextually secure?$] on |settingsObject| is `"Not Secure"`, abort these steps.
-4. Let |browsingContext| be |settingsObject|'s [=global object=]'s [=browsing context=].
+4. Let |browsingContext| be |settingsObject|'s [=environment settings object/global object=]'s [=Window/browsing context=].
 5. If the [=top-level browsing context=] does not equal |browsingContext|, abort these steps.
 6. If |response|'s `Accept-CH` header is present, parse the header field value according to the
     `Accept-CH` header parsing rules, as a [=field-name=]. Add each parsed [=client hints token=] to |settingsObject|'s [=environment settings object/client hints set=].
@@ -171,7 +169,7 @@ Note: This pragma appends [=client hints token=]s to the [=environment settings 
 2. If the <{meta}> element has no <{meta/content}> attribute, or if that attribute's value is the empty string, then return.
 3. Let |settingsObject| be the <{meta}> element's [=relevant settings object=].
 4. If the result of executing [$Is an environment settings object contextually secure?$] on |settingsObject| is `"Not Secure"`, then return.
-5. Let |browsingContext| be |settingsObject|'s  [=global object=]'s [=browsing context=].
+5. Let |browsingContext| be |settingsObject|'s  [=environment settings object/global object=]'s [=Window/browsing context=].
 6. If the [=top-level browsing context=] does not equal |browsingContext|, abort these steps.
 7. Let |acceptCHValue| be the <{meta}> element's <{meta/content}> attribute's value.
 8. Parse |acceptCHValue| according to the [=Accept-CH=] header parsing rules, as a [=field-name=].

--- a/index.bs
+++ b/index.bs
@@ -15,6 +15,8 @@ spec:infra; type:dfn; for:/; text:list
 spec:infra; type:dfn; for:list; text:append
 spec:infra; type:dfn; for:set; text:append
 spec:html; type:dfn; for:/; text:origin
+spec:html; type:dfn; for:environment settings object; text:global object
+spec:html; type:dfn; for:/; text:browsing context
 spec:fetch; type:dfn; for:/; text:fetch
 spec:fetch; type:dfn; for:Request; text:request
 spec:fetch; type:dfn; text:client
@@ -146,7 +148,7 @@ When asked to <dfn abstract-op>initialize the Client Hints set</dfn> with |setti
 1. Let |clientHintsSet| be the result of running [=retrieve the client hints set=] with |settingsObject|'s [=environment settings object/origin=].
 2. For each |hint| in |clientHintsSet|, [=set/append=] |hint| to |settingsObject|'s [=environment settings object/client hints set=].
 3. If the result of executing [$Is an environment settings object contextually secure?$] on |settingsObject| is `"Not Secure"`, abort these steps.
-4. Let |browsingContext| be |settingsObject|'s [=responsible browsing context=].
+4. Let |browsingContext| be |settingsObject|'s [=global object=]'s [=browsing context=].
 5. If the [=top-level browsing context=] does not equal |browsingContext|, abort these steps.
 6. If |response|'s `Accept-CH` header is present, parse the header field value according to the
     `Accept-CH` header parsing rules, as a [=field-name=]. Add each parsed [=client hints token=] to |settingsObject|'s [=environment settings object/client hints set=].
@@ -169,7 +171,7 @@ Note: This pragma appends [=client hints token=]s to the [=environment settings 
 2. If the <{meta}> element has no <{meta/content}> attribute, or if that attribute's value is the empty string, then return.
 3. Let |settingsObject| be the <{meta}> element's [=relevant settings object=].
 4. If the result of executing [$Is an environment settings object contextually secure?$] on |settingsObject| is `"Not Secure"`, then return.
-5. Let |browsingContext| be |settingsObject|'s [=responsible browsing context=].
+5. Let |browsingContext| be |settingsObject|'s  [=global object=]'s [=browsing context=].
 6. If the [=top-level browsing context=] does not equal |browsingContext|, abort these steps.
 7. Let |acceptCHValue| be the <{meta}> element's <{meta/content}> attribute's value.
 8. Parse |acceptCHValue| according to the [=Accept-CH=] header parsing rules, as a [=field-name=].


### PR DESCRIPTION
Since the responsible browsing context [died](https://github.com/whatwg/html/pull/5441/files), this PR replaces it.

/TBR @domenic