### PR TITLE
Update references to Feature Policy

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -22,13 +22,13 @@ spec:fetch; type:dfn; text:client
 
 <pre class=biblio>
 {
-    "FEATURE-POLICY": {
+    "PERMISSIONS-POLICY": {
         "authors": [
             "Ian Clelland"
         ],
-        "href": "https://wicg.github.io/feature-policy/",
-        "publisher": "WICG",
-        "title": "Feature Policy"
+        "href": "https://w3c.github.io/webappsec-permissions-policy/",
+        "publisher": "W3C",
+        "title": "Permissions Policy"
     },
     "CLIENT-HINTS": {
         "authors": [
@@ -68,7 +68,7 @@ delegation mechanism:
     secure-transport origins, instead of appending such data on every outgoing
     request.
 * Origin opt-in applies to same-origin assets only and delivery to third-party
-    origins is subject to explicit first party delegation via Feature Policy,
+    origins is subject to explicit first party delegation via Permissions Policy,
     enabling tight control over which third party origins can access requested
     hint data.
 
@@ -105,8 +105,8 @@ following specifications and proposals:
             redirections.
      - Integrates those concepts with the [[!HTML]] and [[!FETCH]] specifications, 
           by patching various concepts there.
-* W3C Feature Policy specification (<a href="https://w3c.github.io/webappsec-feature-policy/#should-request-be-allowed-to-use-feature">relevant section</a>)
-     - In order to perform third party Client Hint delegation, Feature Policy has
+* W3C Permissions Policy specification (<a href="https://w3c.github.io/webappsec-permissions-policy/#should-request-be-allowed-to-use-feature">relevant section</a>)
+     - In order to perform third party Client Hint delegation, Permissions Policy has
          been extended to control features within fetch requests (rather than just Documents).
 
 Environment settings object processing {#environment-settings-object-processing}
@@ -238,12 +238,12 @@ if <var>request</var>'s <a for=request>header list</a>
 
 
   <li><p>If <var>request</var> is a <a>subresource request</a> and the result of running
-   <a href="https://w3c.github.io/webappsec-feature-policy/#algo-should-request-be-allowed-to-use-feature">Should request be allowed to use feature?</a>,
+   <a href="https://w3c.github.io/webappsec-permissions-policy/#algo-should-request-be-allowed-to-use-feature">Should request be allowed to use feature?</a>,
    given <var>request</var> and <var>hintName</var>’s
    <a href="http://httpwg.org/http-extensions/client-hints.html#opt-in-via-feature-policy">associated
    policy-controlled feature</a>, returns <code>false</code>, then skip the next steps and
    continue to the next <var>hintName</var>.
-   [[!FEATURE-POLICY]] [[!CLIENT-HINTS]]
+   [[!PERMISSIONS-POLICY]] [[!CLIENT-HINTS]]
 
   <li><p>Set <var>hintName</var> to "Sec-" concatenated with <var>hintName</var>.
   <div class=issue>We need to figure out if we really want a `Sec-` prefix, and if so also exempt it from CORS.</div>
@@ -264,12 +264,12 @@ When asked to <dfn abstract-op>remove client hints from redirect if needed</dfn>
   <li><p>Set <var>hintName</var> to "Sec-" concatenated with <var>hintName</var>.
   <li><p>If <var>request</var>'s <a for=request>header list</a> <a for="header list">contains</a>
   <var>hintName</var> and if the result of running <a
-  href="https://wicg.github.io/feature-policy/#should-request-be-allowed-to-use-feature">Should
+  href="https://w3c.github.io/webappsec-permissions-policy/#algo-should-request-be-allowed-to-use-feature">Should
   request be allowed to use feature?</a>, given <var>request</var> and <var>hintName</var>’s
   <a href="http://httpwg.org/http-extensions/client-hints.html#opt-in-via-feature-policy">associated
   policy-controlled feature</a>, returns <code>false</code>, then remove <var>hintName</var> from
   <a for=request>header list</a>.
-  [[!FEATURE-POLICY]] [[!CLIENT-HINTS]]
+  [[!PERMISSIONS-POLICY]] [[!CLIENT-HINTS]]
  </ol>
 </ol>
 


### PR DESCRIPTION
The Feature Policy spec has been renamed to Permissions Policy, and the spec has moved (in some cases, a couple of times) since the URL references here were originally written.