### PR TITLE
Fixes #85 - Add Sec-CH-UA-Full-Version-List bits

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -288,6 +288,7 @@ A <dfn export>client hints token</dfn> is a [=byte-lowercase=] representation of
   `Sec-CH-UA-Arch`,
   `Sec-CH-UA-Bitness`,
   `Sec-CH-UA-Full-Version`,
+  `Sec-CH-UA-Full-Version-List`,
   `Sec-CH-UA-Mobile`,
   `Sec-CH-UA-Model`,
   `Sec-CH-UA-Platform`, or
@@ -316,6 +317,7 @@ the following [=policy-controlled features=]:
 - <code><dfn export>ch-ua-arch</dfn></code> which has a [=default allowlist=] of `'self'`
 - <code><dfn export>ch-ua-bitness</dfn></code> which has a [=default allowlist=] of `'self'`
 - <code><dfn export>ch-ua-full-version</dfn></code> which has a [=default allowlist=] of `'self'`
+- <code><dfn export>ch-ua-full-version-list</dfn></code> which has a [=default allowlist=] of `'self'`
 - <code><dfn export>ch-ua-mobile</dfn></code> which has a [=default allowlist=] of `'*'`
 - <code><dfn export>ch-ua-model</dfn></code> which has a [=default allowlist=] of `'self'`
 - <code><dfn export>ch-ua-platform</dfn></code> which has a [=default allowlist=] of `'*'`
@@ -381,6 +383,8 @@ When asked to <dfn>find client hint value</dfn>, given |hint| as input, switch o
   <dd>a suitable <a href=https://wicg.github.io/ua-client-hints/#sec-ch-ua-bitness>Bitness value</a>
   <dt>`UA-Full-Version`
   <dd>a suitable <a href=https://wicg.github.io/ua-client-hints/#sec-ch-ua-full-version>Full-Version value</a>
+  <dt>`UA-Full-Version-List`
+  <dd>a suitable <a href=https://wicg.github.io/ua-client-hints/#sec-ch-ua-full-version-list>Full-Version-List value</a>
   <dt>`UA-Mobile`
   <dd>a suitable <a href=https://wicg.github.io/ua-client-hints/#sec-ch-ua-mobile>Mobile value</a>
   <dt>`UA-Model`


### PR DESCRIPTION
PTAL, @yoavweiss 

To be landed once https://github.com/WICG/ua-client-hints/pull/250 is ready to land.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/client-hints-infrastructure/pull/86.html" title="Last updated on Sep 9, 2021, 9:54 PM UTC (06cc1da)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/86/59100e6...miketaylr:06cc1da.html" title="Last updated on Sep 9, 2021, 9:54 PM UTC (06cc1da)">Diff</a>