### PR TITLE
Fix Client Hint Redirect Calculation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -241,19 +241,13 @@ When asked to <dfn abstract-op>update client hints from redirect if needed</dfn>
  <ol>
   <li><p>Set <var>hintName</var> to "Sec-" concatenated with <var>hintName</var>.
   <li><p>If <var>request</var>'s <a for=request>header list</a> <a for="header list">contains</a>
-  <var>hintName</var> and if the result of running <a
-  href="https://w3c.github.io/webappsec-permissions-policy/#algo-should-request-be-allowed-to-use-feature">Should
-  request be allowed to use feature?</a>, given <var>request</var> and <var>hintName</var>’s
-  <a href="#policy-controlled-features">associated
-  policy-controlled feature</a>, returns <code>false</code>, then remove <var>hintName</var> from
-  <a for=request>header list</a>.
+  <var>hintName</var> and if the result of running [=Permissions Policy/Should request be allowed to use feature?=],
+  given <var>request</var> and <var>hintName</var>’s <a href="#policy-controlled-features">associated
+  policy-controlled feature</a>, returns <code>false</code>, then remove <var>hintName</var> from |request|'s [=request/header list=].
   <li><p>Else if <var>request</var>'s <a for=request>header list</a> <a for="header list">doesn't contain</a>
-  <var>hintName</var> and if the result of running <a
-  href="https://w3c.github.io/webappsec-permissions-policy/#algo-should-request-be-allowed-to-use-feature">Should
-  request be allowed to use feature?</a>, given <var>request</var> and <var>hintName</var>’s
-  <a href="#policy-controlled-features">associated
-  policy-controlled feature</a>, returns <code>true</code>, then add <var>hintName</var> to
-  <a for=request>header list</a>.
+  <var>hintName</var> and if the result of running [=Permissions Policy/Should request be allowed to use feature?=],
+  given <var>request</var> and <var>hintName</var>’s <a href="#policy-controlled-features">associated
+  policy-controlled feature</a>, returns <code>true</code>, then add <var>hintName</var> to |request|'s [=request/header list=].
  </ol>
 </ol>
 

--- a/index.bs
+++ b/index.bs
@@ -241,11 +241,11 @@ When asked to <dfn abstract-op>update client hints from redirect if needed</dfn>
  <ol>
   <li><p>Set <var>hintName</var> to "Sec-" concatenated with <var>hintName</var>.
   <li><p>If <var>request</var>'s <a for=request>header list</a> <a for="header list">contains</a>
-  <var>hintName</var> and if the result of running [$Should request be allowed to use feature?$],
+  <var>hintName</var> and if the result of running [=Should request be allowed to use feature?=],
   given <var>request</var> and <var>hintName</var>’s <a href="#policy-controlled-features">associated
   policy-controlled feature</a>, returns <code>false</code>, then remove <var>hintName</var> from |request|'s [=request/header list=].
   <li><p>Else if <var>request</var>'s <a for=request>header list</a> <a for="header list">doesn't contain</a>
-  <var>hintName</var> and if the result of running [$Should request be allowed to use feature?$],
+  <var>hintName</var> and if the result of running [=Should request be allowed to use feature?=],
   given <var>request</var> and <var>hintName</var>’s <a href="#policy-controlled-features">associated
   policy-controlled feature</a>, returns <code>true</code>, then add <var>hintName</var> to |request|'s [=request/header list=].
  </ol>

--- a/index.bs
+++ b/index.bs
@@ -235,17 +235,17 @@ contain=] |hintName|:
 When asked to <dfn abstract-op>update client hints from redirect if needed</dfn> with |request| as input, run the following steps:
 
 <ol>
- <li>If |request|'s [=client=] is null, then abort these steps.
- <li>Let |clientHintsSet| be the set of all client hints supported by the [=user agent=].
+ <li>If |request|'s [=request/client=] is null, then abort these steps.
+ <li>Let |clientHintsSet| be |request|'s <var ignore>client</var>'s [=environment settings object/client hints set=].
  <li><p><a for=list>For each</a> <var>hintName</var> of |clientHintsSet|:
  <ol>
   <li><p>Set <var>hintName</var> to "Sec-" concatenated with <var>hintName</var>.
   <li><p>If <var>request</var>'s <a for=request>header list</a> <a for="header list">contains</a>
-  <var>hintName</var> and if the result of running [=Permissions Policy/Should request be allowed to use feature?=],
+  <var>hintName</var> and if the result of running [=Should request be allowed to use feature?=],
   given <var>request</var> and <var>hintName</var>’s <a href="#policy-controlled-features">associated
   policy-controlled feature</a>, returns <code>false</code>, then remove <var>hintName</var> from |request|'s [=request/header list=].
   <li><p>Else if <var>request</var>'s <a for=request>header list</a> <a for="header list">doesn't contain</a>
-  <var>hintName</var> and if the result of running [=Permissions Policy/Should request be allowed to use feature?=],
+  <var>hintName</var> and if the result of running [=Should request be allowed to use feature?=],
   given <var>request</var> and <var>hintName</var>’s <a href="#policy-controlled-features">associated
   policy-controlled feature</a>, returns <code>true</code>, then add <var>hintName</var> to |request|'s [=request/header list=].
  </ol>

--- a/index.bs
+++ b/index.bs
@@ -245,7 +245,7 @@ When asked to <dfn abstract-op>update client hints from redirect if needed</dfn>
   given <var>request</var> and <var>hintName</var>’s <a href="#policy-controlled-features">associated
   policy-controlled feature</a>, returns <code>false</code>, then remove <var>hintName</var> from |request|'s [=request/header list=].
   <li><p>Else if <var>request</var>'s <a for=request>header list</a> <a for="header list">doesn't contain</a>
-  <var>hintName</var> and if the result of running [=Should request be allowed to use feature?=],
+  <var>hintName</var> and if the result of running [$Should request be allowed to use feature?$],
   given <var>request</var> and <var>hintName</var>’s <a href="#policy-controlled-features">associated
   policy-controlled feature</a>, returns <code>true</code>, then add <var>hintName</var> to |request|'s [=request/header list=].
  </ol>

--- a/index.bs
+++ b/index.bs
@@ -241,7 +241,7 @@ When asked to <dfn abstract-op>update client hints from redirect if needed</dfn>
  <ol>
   <li><p>Set <var>hintName</var> to "Sec-" concatenated with <var>hintName</var>.
   <li><p>If <var>request</var>'s <a for=request>header list</a> <a for="header list">contains</a>
-  <var>hintName</var> and if the result of running [=Should request be allowed to use feature?=],
+  <var>hintName</var> and if the result of running [$Should request be allowed to use feature?$],
   given <var>request</var> and <var>hintName</var>’s <a href="#policy-controlled-features">associated
   policy-controlled feature</a>, returns <code>false</code>, then remove <var>hintName</var> from |request|'s [=request/header list=].
   <li><p>Else if <var>request</var>'s <a for=request>header list</a> <a for="header list">doesn't contain</a>

--- a/index.bs
+++ b/index.bs
@@ -232,11 +232,11 @@ contain=] |hintName|:
  </ol>
 </ol>
 
-When asked to <dfn abstract-op>remove client hints from redirect if needed</dfn> with |request| as input, run the following steps:
+When asked to <dfn abstract-op>update client hints from redirect if needed</dfn> with |request| as input, run the following steps:
 
 <ol>
  <li>If |request|'s [=client=] is null, then abort these steps.
- <li>Let |clientHintsSet| be |request|'s <var ignore>client</var>'s [=environment settings object/client hints set=].
+ <li>Let |clientHintsSet| be the set of all client hints supported by the [=user agent=].
  <li><p><a for=list>For each</a> <var>hintName</var> of |clientHintsSet|:
  <ol>
   <li><p>Set <var>hintName</var> to "Sec-" concatenated with <var>hintName</var>.
@@ -247,7 +247,13 @@ When asked to <dfn abstract-op>remove client hints from redirect if needed</dfn>
   <a href="#policy-controlled-features">associated
   policy-controlled feature</a>, returns <code>false</code>, then remove <var>hintName</var> from
   <a for=request>header list</a>.
-  [[!PERMISSIONS-POLICY]]
+  <li><p>Else if <var>request</var>'s <a for=request>header list</a> <a for="header list">doesn't contain</a>
+  <var>hintName</var> and if the result of running <a
+  href="https://w3c.github.io/webappsec-permissions-policy/#algo-should-request-be-allowed-to-use-feature">Should
+  request be allowed to use feature?</a>, given <var>request</var> and <var>hintName</var>’s
+  <a href="#policy-controlled-features">associated
+  policy-controlled feature</a>, returns <code>true</code>, then add <var>hintName</var> to
+  <a for=request>header list</a>.
  </ol>
 </ol>
 
@@ -258,7 +264,7 @@ This specification integrates with the [[!FETCH]] specification by patching the 
 
 In [=Fetching=], after step 1.6, run [$append client hints to request$] with |request| as input.
 
-In [=HTTP-redirect fetch=], after step 7, run [$remove client hints from redirect if needed$] with |request| as input.
+In [=HTTP-redirect fetch=], after step 7, run [$update client hints from redirect if needed$] with |request| as input.
 
 Feature Registry {#registry}
 ==========


### PR DESCRIPTION
We need to add new client hints which should be sent, not just remove ones that shouldn't.

closes #48
closes #39


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/pull/95.html" title="Last updated on Jan 28, 2022, 9:56 PM UTC (93ff7bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/95/ebc6ee0...93ff7bb.html" title="Last updated on Jan 28, 2022, 9:56 PM UTC (93ff7bb)">Diff</a>