### PR TITLE
Revert Sec-CH-Save-Data to Save-Data and retain original behavior

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -344,7 +344,7 @@ The <dfn export>low entropy hint table</dfn> below defines hints that are only e
   <td>a suitable <a href=https://wicg.github.io/ua-client-hints/#sec-ch-ua-platform>Platform value</a>
 </table>
 
-Note: If the value transmitted by `Save-Data` is false (`?0`) the header will be ommitted entirely.
+Note: If the value transmitted by `Save-Data` is the empty string, the header will be ommitted entirely.
 This is done to reduce redundant header information sent by default.
 
 Find client hint value {#find-client-hint-value-section}

--- a/index.bs
+++ b/index.bs
@@ -269,7 +269,7 @@ Client hints token {#client-hints-token-definition}
 ----------
 
 A <dfn export>client hints token</dfn> is a [=byte-lowercase=] representation of one of
-`Sec-CH-Save-Data`,
+`Save-Data`,
 `Sec-CH-DPR`,
 `Sec-CH-Width`,
 `Sec-CH-Viewport-Width`,
@@ -331,7 +331,7 @@ The <dfn export>low entropy hint table</dfn> below defines hints that are only e
   <th><a for=header>Value</a>
  <tbody>
  <tr>
-  <td>`Sec-CH-Save-Data`
+  <td>`Save-Data`
   <td>a suitable <a href=https://wicg.github.io/savedata/#save-data-request-header-field>Save-Data value</a>
  <tr>
   <td>`Sec-CH-UA`
@@ -344,7 +344,7 @@ The <dfn export>low entropy hint table</dfn> below defines hints that are only e
   <td>a suitable <a href=https://wicg.github.io/ua-client-hints/#sec-ch-ua-platform>Platform value</a>
 </table>
 
-Note: If the value transmitted by a low entropy hint header is the empty string, zero, or false (`?0`) the header will be ommitted entirely.
+Note: If the value transmitted by `Save-Data` is false (`?0`) the header will be ommitted entirely.
 This is done to reduce redundant header information sent by default.
 
 Find client hint value {#find-client-hint-value-section}

--- a/index.bs
+++ b/index.bs
@@ -344,6 +344,9 @@ The <dfn export>low entropy hint table</dfn> below defines hints that are only e
   <td>a suitable <a href=https://wicg.github.io/ua-client-hints/#sec-ch-ua-platform>Platform value</a>
 </table>
 
+Note: If the value transmitted by a low entropy hint header is the empty string, zero, or false (`?0`) the header will be ommitted entirely.
+This is done to reduce redundant header information sent by default.
+
 Find client hint value {#find-client-hint-value-section}
 ------------
 


### PR DESCRIPTION
closes #99

This change is the result of a discussion on the intent to ship thread: https://groups.google.com/a/chromium.org/g/blink-dev/c/HR7tWmewbSA/m/f4le2e8yDAAJ


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/pull/101.html" title="Last updated on Mar 24, 2022, 7:48 PM UTC (9acd92d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/101/7ee781c...9acd92d.html" title="Last updated on Mar 24, 2022, 7:48 PM UTC (9acd92d)">Diff</a>