### PR TITLE
Limit meta tag parsing to one root, original tag

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -183,9 +183,13 @@ Integration with HTML {#html}
 
 This specification integrates with the [[!HTML]] specification by patching the algorithms below:
 
+Speculative HTML parsing {#speculative-html-parsing}
+----------
+At [=speculative fetch=], after the sub-step for the meta element "viewport" step add a new sub-step with the following:
+"A meta element whose name attribute is an ASCII case-insensitive match for "accept-ch" (only if this element is in the root Document and has not been modified by any script execution)."
+
 Navigation response {#navigation-response}
 ----------
-
 At [=process a navigate response=], after step 7 call [$update the Client Hints set$] with the [=relevant settings object=] and |response| as inputs.
 
 Worker initialization {#worker-init}
@@ -197,13 +201,12 @@ after step 6, add the following step:
 Standard metadata names {#standard-metadata-names}
 ------------
 For the section <a href="https://html.spec.whatwg.org/multipage/#standard-metadata-names">standard metadata names</a>,
-add a subsection named `accept-ch` with the [=Accept-CH state|outlined explanation=].
+add a subsection named `accept-ch` with the [=Accept-CH state|outlined explanation=]. Note that this should be run exactly once,
+and only on an element in the root Document which has not been modified by any script execution.
 
 Extending environment settings object {#extending-environment-settings-object}
 -------------
-
 An [=environment settings object=] has a <dfn for="environment settings object">client hints set</dfn>: a [=/client hints set=], initially the empty set, used for [=fetches=] performed using the [=environment settings object=] as a [=request=] [=client=].
-
 
 Request processing {#request-processing}
 ===========

--- a/index.bs
+++ b/index.bs
@@ -154,10 +154,12 @@ When asked to <dfn abstract-op>update the Client Hints set</dfn> given a |settin
 <dfn>Accept-CH state</dfn> (`name="accept-ch"`) {#accept-ch-state-algo}
 --------
 
-Note: This metadata *appends* [=client hints token=]s to the [=environment settings object=]'s [=environment settings object/client hints set=]. It *does not* add those hints to the [=Accept-CH cache=]. After this algorithm runs once, no further modification to the [=environment settings object/client hints set=] can occur without reloading the page.
+Note: This metadata *appends* [=client hints token=]s to the [=environment settings object=]'s [=environment settings object/client hints set=] and *does not* add those hints to the [=Accept-CH cache=].
 
 <ol>
+ <li>If [=environment settings object/client hints set=] has already been modified by this algorithm, then return.
  <li>Let |metaElement| be the <{meta}> element.
+ <li>If |metaElement| is not in the root document, then return.
  <li>If |metaElement| is not a child of a <{head}> element, then return.
  <li>If |metaElement| has no <{meta/content}> attribute, or if that attribute's value is the empty string, then return.
  <li>If |metaElement| has any <a href="https://dom.spec.whatwg.org/#concept-tree-preceding">preceding</a> <a href="https://dom.spec.whatwg.org/#concept-tree-sibling">sibling</a> <{link}> or <{script}> elements (or if any <{link}> or <{script}> elements have begun to execute), then return.

--- a/index.bs
+++ b/index.bs
@@ -187,7 +187,7 @@ This specification integrates with the [[!HTML]] specification by patching the a
 
 Speculative HTML parsing {#speculative-html-parsing}
 ----------
-At [=speculative html parsing=], after the sub-step for the meta element "viewport" step add a new sub-step with the following:
+At [=speculative HTML parser=], after the sub-step for the meta element "viewport" step add a new sub-step with the following:
 "A meta element whose name attribute is an ASCII case-insensitive match for "accept-ch"."
 
 Navigation response {#navigation-response}

--- a/index.bs
+++ b/index.bs
@@ -185,8 +185,8 @@ This specification integrates with the [[!HTML]] specification by patching the a
 
 Speculative HTML parsing {#speculative-html-parsing}
 ----------
-At [=speculative fetch=], after the sub-step for the meta element "viewport" step add a new sub-step with the following:
-"A meta element whose name attribute is an ASCII case-insensitive match for "accept-ch" (only if this element is in the root Document and has not been modified by any script execution)."
+At [=speculative html parsing=], after the sub-step for the meta element "viewport" step add a new sub-step with the following:
+"A meta element whose name attribute is an ASCII case-insensitive match for "accept-ch"."
 
 Navigation response {#navigation-response}
 ----------
@@ -201,8 +201,7 @@ after step 6, add the following step:
 Standard metadata names {#standard-metadata-names}
 ------------
 For the section <a href="https://html.spec.whatwg.org/multipage/#standard-metadata-names">standard metadata names</a>,
-add a subsection named `accept-ch` with the [=Accept-CH state|outlined explanation=]. Note that this should be run exactly once,
-and only on an element in the root Document which has not been modified by any script execution.
+add a subsection named `accept-ch` with the [=Accept-CH state|outlined explanation=].
 
 Extending environment settings object {#extending-environment-settings-object}
 -------------


### PR DESCRIPTION
This also adds support for speculative HTML parsing, whose fetches should respect the tag as well.

https://github.com/w3ctag/design-reviews/issues/702#issuecomment-1076530567


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/pull/103.html" title="Last updated on Mar 28, 2022, 9:36 PM UTC (10bd668)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/103/7ee781c...10bd668.html" title="Last updated on Mar 28, 2022, 9:36 PM UTC (10bd668)">Diff</a>