### PR TITLE
Define "high-entropy client hint"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -320,9 +320,13 @@ the following [=policy-controlled features=]:
 
 Issue: Should we tie low-entropy-ness to allowlists, generally?
 
-Low entropy hint table {#low-entropy-table}
+Low-entropy hint table {#low-entropy-table}
 -------
-The <dfn export>low entropy hint table</dfn> below defines hints that are only exposing low amounts of entropy.
+The <dfn export lt="low-entropy hint table|low entropy hint table">low-entropy hint table</dfn>
+below defines hints that are only exposing low amounts of entropy.
+
+A <dfn export>high-entropy client hint</dfn> is a client hint that is not in the
+<a>low-entropy hint table</a>.
 
 <table>
  <thead>

--- a/index.bs
+++ b/index.bs
@@ -323,7 +323,7 @@ Issue: Should we tie low-entropy-ness to allowlists, generally?
 Low-entropy hint table {#low-entropy-table}
 -------
 The <dfn export lt="low-entropy hint table|low entropy hint table">low-entropy hint table</dfn>
-below defines hints that are only exposing low amounts of entropy.
+below defines hints that are safe to send by default due to their low amounts of entropy.
 
 A <dfn export>high-entropy client hint</dfn> is a client hint that is not in the
 <a>low-entropy hint table</a>.


### PR DESCRIPTION
PTAL @yoavweiss 

(we could also add a note to clarify this means all hints are high-entropy by default, but maybe that's obvious)

Fixes #126


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/client-hints-infrastructure/pull/127.html" title="Last updated on Sep 19, 2022, 1:09 PM UTC (3b2a22a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/127/63db401...miketaylr:3b2a22a.html" title="Last updated on Sep 19, 2022, 1:09 PM UTC (3b2a22a)">Diff</a>