### PR TITLE
Add WoW64 UA CH to spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -285,8 +285,9 @@ A <dfn export>client hints token</dfn> is a [=byte-lowercase=] representation of
 `Sec-CH-UA-Full-Version-List`,
 `Sec-CH-UA-Mobile`,
 `Sec-CH-UA-Model`,
-`Sec-CH-UA-Platform`, or
-`Sec-CH-UA-Platform-Version`,
+`Sec-CH-UA-Platform`,
+`Sec-CH-UA-Platform-Version`, or
+`Sec-CH-UA-WoW64`.
 
 Note: A client hints token will also match the request header sent by the user agent when
 appropriate (as determined by the <a href="#request-processing">request processing algorithm</a>).
@@ -317,6 +318,7 @@ the following [=policy-controlled features=]:
 - <code><dfn export>ch-ua-model</dfn></code> which has a [=default allowlist=] of `'self'`
 - <code><dfn export>ch-ua-platform</dfn></code> which has a [=default allowlist=] of `'*'`
 - <code><dfn export>ch-ua-platform-version</dfn></code> which has a [=default allowlist=] of `'self'`
+- <code><dfn export>ch-ua-wow64</dfn></code> which has a [=default allowlist=] of `'self'`
 
 Issue: Should we tie low-entropy-ness to allowlists, generally?
 
@@ -396,6 +398,8 @@ When asked to <dfn>find client hint value</dfn>, given |hint| as input, switch o
   <dd>a suitable <a href="https://wicg.github.io/ua-client-hints/#sec-ch-ua-platform">Platform value</a>
   <dt>`UA-Platform-Version`
   <dd>a suitable <a href="https://wicg.github.io/ua-client-hints/#sec-ch-ua-platform-version">Platform-Version value</a>
+  <dt>`UA-WoW64`
+  <dd>a suitable <a href="https://wicg.github.io/ua-client-hints/#sec-ch-ua-wow64">WoW64 value</a>
  </dl>
 
 Issue: Links for image features are broken, need to actually define that and link to them.


### PR DESCRIPTION
This was missing from the list despite being defined here: https://wicg.github.io/ua-client-hints/#sec-ch-ua-wow64

![image](https://user-images.githubusercontent.com/666538/193088212-d152873d-e622-4056-a23b-fadb8b57a30a.png)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/pull/129.html" title="Last updated on Sep 29, 2022, 4:34 PM UTC (e085471)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/129/1a90cb9...e085471.html" title="Last updated on Sep 29, 2022, 4:34 PM UTC (e085471)">Diff</a>