### PR TITLE
Fix fetch point of integration

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -252,7 +252,7 @@ Integration with Fetch {#fetch}
 
 This specification integrates with the [[!FETCH]] specification by patching the algorithms below:
 
-In <a spec=FETCH>Main Fetch</a>, after step 9, run [$append client hints to request$] with the [=relevant settings object=] and |request| as input.
+In <a spec=FETCH>HTTP-network-or-cache fetch</a>, within step 8, after substep 23, run [$append client hints to request$] with the [=relevant settings object=] and |request| as input.
 
 In [=HTTP-redirect fetch=], after step 11, run [$remove client hints from redirect if needed$] with |request| as input.
 


### PR DESCRIPTION
closes #130 

UA infra's point of connection with the Fetch spec is too early up the stack, and append CH needs to be called lower (after the CORS checks)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/pull/131.html" title="Last updated on Oct 4, 2022, 2:51 PM UTC (36262bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/131/9c77cba...36262bb.html" title="Last updated on Oct 4, 2022, 2:51 PM UTC (36262bb)">Diff</a>