### PR TITLE
Update CORS forbidden headers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -262,7 +262,7 @@ In <a spec=FETCH>HTTP-network-or-cache fetch</a>, within step 8, after substep 2
 
 In [=HTTP-redirect fetch=], after step 11, run [$remove client hints from redirect if needed$] with |request| as input.
 
-In [=forbidden request header=], to the list of headers within step 1, add `Save-Data`, `DPR`, `Device-Memory`, `Width`, and `Viewport-Width`.
+In [=forbidden request-header=], to the list of headers within step 1, add `Save-Data`, `DPR`, `Device-Memory`, `Width`, and `Viewport-Width`.
 
 Feature Registry {#registry}
 ==========

--- a/index.bs
+++ b/index.bs
@@ -262,6 +262,8 @@ In <a spec=FETCH>HTTP-network-or-cache fetch</a>, within step 8, after substep 2
 
 In [=HTTP-redirect fetch=], after step 11, run [$remove client hints from redirect if needed$] with |request| as input.
 
+In [=forbidden request header=], to the list of headers within step 1, add `Save-Data`, `DPR`, `Device-Memory`, `Width`, and `Viewport-Width`.
+
 Feature Registry {#registry}
 ==========
 


### PR DESCRIPTION
Any client hints that don't start with `sec-` need to be manually listed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/pull/133.html" title="Last updated on Dec 13, 2022, 4:57 PM UTC (36dc5c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/133/e4b5a58...36dc5c1.html" title="Last updated on Dec 13, 2022, 4:57 PM UTC (36dc5c1)">Diff</a>