### PR TITLE
Export "append client hints to request" abstract-op

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -246,7 +246,7 @@ Note: This metadata *appends* [=client hints token=]s to the [=environment setti
   <li>[=set/Append=] |feature| to |settingsObject|'s [=environment settings object/client hints set=] and [=set/Append=] |filteredAllowList| to |permissionsPolicy|[|feature|]'s [[PERMISSIONS-POLICY|permissions policy]].
  </ol>
 </ol>
-     
+
 Issue(110): Clarify detection of <{link}>, <{style}>, or <{script}> element execution.
 
 Interaction with `ACCEPT_CH` frame {#interaction-with-accept-ch-frame}
@@ -311,7 +311,7 @@ An [=environment settings object=] has a <dfn for="environment settings object">
 Request processing {#request-processing}
 ===========
 
-When asked to <dfn abstract-op>append client hints to request</dfn> with |settingsObject| and |request| as input, run the
+When asked to <dfn export abstract-op>append client hints to request</dfn> with |settingsObject| and |request| as input, run the
 following steps:
 
 <ol>


### PR DESCRIPTION
Then I can properly link to it from UA-CH:

https://github.com/WICG/ua-client-hints/blob/main/index.bs#L48


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/client-hints-infrastructure/pull/143.html" title="Last updated on Feb 9, 2023, 12:32 AM UTC (93d14e9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/143/09219c0...miketaylr:93d14e9.html" title="Last updated on Feb 9, 2023, 12:32 AM UTC (93d14e9)">Diff</a>