### PR TITLE
Correct Critical-CH definition point

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -95,11 +95,8 @@ following specifications and proposals:
 
 * IETF [[!RFC8942]]
      - Provides the motivation for Client Hints.
-     - Defines the fundamental Client Hints infrastructure:
-        - The `Accept-CH` response header, which servers may use to advertise
-            support for certain Client Hints.
-        - The `Critical-CH` response header, which servers may use to request a reload
-            to include critical Client Hints missing in the initial load.
+     - Defines the `Accept-CH` response header, which servers may use to advertise
+         support for certain Client Hints.
      - Provides both general guidelines, and formal requirements, about Client
          Hints’ impact on caching, security, and privacy.
      - Does *not* define any actual, particular hints – or say anything about how
@@ -115,8 +112,10 @@ following specifications and proposals:
             same-origin or delegated-to cross-origin requests. It also makes sure
             hints are removed from not delegated-to cross-origin requests after
             redirections.
+     - Defines the `Critical-CH` response header, which servers may use to request a reload	
+         to include critical Client Hints missing in the initial load.
      - Integrates those concepts with the [[!HTML]] and [[!FETCH]] specifications,
-          by patching various concepts there.
+         by patching various concepts there.
 * [[PERMISSIONS-POLICY|W3C Permissions Policy specification]]
      - In order to perform third party Client Hint delegation, Permissions Policy has
          been extended to control features within fetch requests (rather than just Documents). See [[permissions-policy#algo-should-request-be-allowed-to-use-feature]]


### PR DESCRIPTION
This isn't referenced in the RFC, and I didn't see one it was noted in. closes #144


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/pull/145.html" title="Last updated on Feb 10, 2023, 3:16 PM UTC (d4f247f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/145/510827b...d4f247f.html" title="Last updated on Feb 10, 2023, 3:16 PM UTC (d4f247f)">Diff</a>