### PR TITLE
Simplify `append client hints to request`'s Step 6.1

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -333,8 +333,11 @@ following steps:
 |hintSet|.
  <li>For each |hintName| in |hintSet|:
  <ol>
-   <li>If |request| is not a [=navigation request=] for a "document" [=request/destination=] and if the result of running [[permissions-policy#algo-should-request-be-allowed-to-use-feature]]
-   given |request| and |hintName|'s associated feature in [[#policy-controlled-features]] returns `false`, then continue to next |hintName|.
+   <li>If |request| is not a [=navigation request=] for a "document" [=request/destination=]:
+   <ol>
+     <li>Let |requestPermitsHint| be the result of running [[permissions-policy#algo-should-request-be-allowed-to-use-feature]] given |request| and |hintName|'s associated feature in [[#policy-controlled-features]].
+     <li>If |requestPermitsHint| is `false`, then continue to next |hintName|.
+   </ol>
    <li>If the user agent decides, in an [=implementation-defined=] way (see [[#privacy]]), to omit this hint then continue.
    <li>Let |value| be the result of running [=find client hint value=] with |hintName|.
    <li>If the user agent decides, in an [=implementation-defined=] way (see [[#privacy]]), to modify |value| then do so.


### PR DESCRIPTION
This should be a no-op logic wise, just cleaning for clarity.

closes #151


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/pull/152.html" title="Last updated on Apr 26, 2023, 11:42 AM UTC (275d17f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/152/a163e1d...275d17f.html" title="Last updated on Apr 26, 2023, 11:42 AM UTC (275d17f)">Diff</a>