### PR TITLE
Update Critical-CH restart time in navigation params

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -277,7 +277,7 @@ Navigable {#navigable}
 
 Add a new field to [=navigable=]:
 <ul>
- <li>A <dfn>`Critical-CH` restart time</dfn> {{DOMHighResTimeStamp}}, initially 0.
+ <li>A <dfn>`Critical-CH` restart time cache</dfn> {{DOMHighResTimeStamp}}, initially 0.
 </ul>
 
 Navigation response {#navigation-response}
@@ -293,18 +293,18 @@ At [=populating a session history entry=], in step 6 after substep 7 insert the 
  <li>Run [$create or override the cached client hints set$] with the [=relevant settings object=] and |response| as inputs.
  <li>If |shouldReloadForCriticalClientHints| then:
  <ol>
-   <li>Set <var>navigable</var>'s [=Critical-CH restart time=] to the [=current high resolution time=].
+   <li>Set <var>navigable</var>'s [=Critical-CH restart time cache=] to the [=current high resolution time=].
    <li><a spec=HTML>reload</a> <var>navigable</var>.
  </ol>
- <li>If <var>navigable</var>'s [=Critical-CH restart time=] is not 0:
+ <li>If <var>navigable</var>'s [=Critical-CH restart time cache=] is not 0:
  <ol>
-    <li>Set <var>navigationParams</var>'s [=Critical-CH restart time=] to be <var>navigable</var>'s [=Critical-CH restart time=].
+    <li>Set <var>navigationParams</var>'s [=Critical-CH restart time=] to be <var>navigable</var>'s [=Critical-CH restart time cache=].
  </ol>
 </ol>
 
 At [=navigation params=], append the following:
 <dl>
-<dt><dfn>Critical-CH restart time</dfn></dt>
+<dt><dfn>`Critical-CH` restart time</dfn></dt>
   <dd>a {{DOMHighResTimeStamp}} used for [=creating the navigation timing entry=] for the new <code>Document</code></dd>
 </dl>
 

--- a/index.bs
+++ b/index.bs
@@ -280,7 +280,7 @@ Navigable {#navigable}
 Add a new field to [=navigable=]:
 <ul>
  <li>A <dfn>`Critical-CH` restart time</dfn> {{DOMHighResTimeStamp}}, initially 0.
- This records the time the navigation was restarted due to ensure required Client Hint
+ This records the time the navigation was restarted to ensure required Client Hint
  headers will be sent.
 </ul>
 
@@ -310,7 +310,7 @@ At [=navigation params=], append the following:
 <dl>
 <dt>[=Critical-CH restart time=]</dt>
   <dd>a {{DOMHighResTimeStamp}} used for [=creating the navigation timing entry=] for the new <code>Document</code>.
-  This records the time the navigation was restarted due to ensure required Client Hint headers will be sent.</dd>
+  This records the time the navigation was restarted to ensure required Client Hint headers will be sent.</dd>
 </dl>
 
 

--- a/index.bs
+++ b/index.bs
@@ -195,6 +195,8 @@ needed as they were sent. If hints listed in the `Critical-CH` header are not
 in the `Accept-CH` header a restart would not result in the hints being included
 anyway.
 
+The restart retries the entire navigation (including any prior redirects).
+
 There MAY be multiple `Critical-CH` headers per-response and <a>sf-lists</a> can be split across lines as long as each line contains at least one token.
 
 When asked if the user agent <dfn abstract-op>should restart loading the page for critical client hints</dfn> given a |settingsObject| and |response|:
@@ -277,7 +279,9 @@ Navigable {#navigable}
 
 Add a new field to [=navigable=]:
 <ul>
- <li>A <dfn>`Critical-CH` restart time cache</dfn> {{DOMHighResTimeStamp}}, initially 0.
+ <li>A <dfn>`Critical-CH` restart time</dfn> {{DOMHighResTimeStamp}}, initially 0.
+ This records the time the navigation was restarted due to ensure required Client Hint
+ headers will be sent.
 </ul>
 
 Navigation response {#navigation-response}
@@ -286,26 +290,27 @@ Navigation response {#navigation-response}
 At [=populating a session history entry=], in step 6 after substep 7 insert the following:
 <ol>
  <li>Let |shouldRestartForCriticalClientHints| be `false`.
- <li>If <var>navigable</var>'s [=Critical-CH restart time cache=] is 0:
+ <li>If <var>navigable</var>'s [=Critical-CH restart time=] is 0:
  <ol>
    <li>Let |shouldRestartForCriticalClientHints| be the result of running [$should restart page for critical client hints$] with the [=relevant settings object=] and |response|.
  </ol>
  <li>Run [$create or override the cached client hints set$] with the [=relevant settings object=] and |response| as inputs.
  <li>If |shouldRestartForCriticalClientHints| then:
  <ol>
-   <li>Set <var>navigable</var>'s [=Critical-CH restart time cache=] to the [=current high resolution time=].
+   <li>Set <var>navigable</var>'s [=Critical-CH restart time=] to the [=current high resolution time=].
    <li><a spec=HTML>reload</a> <var>navigable</var>.
  </ol>
- <li>If <var>navigable</var>'s [=Critical-CH restart time cache=] is not 0:
+ <li>If <var>navigable</var>'s [=Critical-CH restart time=] is not 0:
  <ol>
-    <li>Set <var>navigationParams</var>'s [=Critical-CH restart time=] to be <var>navigable</var>'s [=Critical-CH restart time cache=].
+    <li>Set <var>navigationParams</var>'s [=Critical-CH restart time=] to be <var>navigable</var>'s [=Critical-CH restart time=].
  </ol>
 </ol>
 
 At [=navigation params=], append the following:
 <dl>
-<dt><dfn>`Critical-CH` restart time</dfn></dt>
-  <dd>a {{DOMHighResTimeStamp}} used for [=creating the navigation timing entry=] for the new <code>Document</code></dd>
+<dt>[=Critical-CH restart time=]</dt>
+  <dd>a {{DOMHighResTimeStamp}} used for [=creating the navigation timing entry=] for the new <code>Document</code>.
+  This records the time the navigation was restarted due to ensure required Client Hint headers will be sent.</dd>
 </dl>
 
 

--- a/index.bs
+++ b/index.bs
@@ -306,6 +306,8 @@ At [=populating a session history entry=], in step 6 after substep 7 insert the 
  </ol>
 </ol>
 
+Issue(154): Clarify how the restart logic integrates with the HTML spec.
+
 At [=navigation params=], append the following:
 <dl>
 <dt>`Critical-CH` restart time</dt>

--- a/index.bs
+++ b/index.bs
@@ -306,7 +306,7 @@ At [=populating a session history entry=], in step 6 after substep 7 insert the 
  </ol>
 </ol>
 
-Issue(154): Clarify how the restart logic integrates with the HTML spec.
+Issue(154): Clarify how "Restart the initial navigation (before any redirects)" integrates with the HTML spec.
 
 At [=navigation params=], append the following:
 <dl>

--- a/index.bs
+++ b/index.bs
@@ -298,7 +298,7 @@ At [=populating a session history entry=], in step 6 after substep 7 insert the 
  <li>If |shouldRestartForCriticalClientHints| then:
  <ol>
    <li>Set <var>navigable</var>'s [=Critical-CH restart time=] to the [=current high resolution time=].
-   <li><a spec=HTML>reload</a> <var>navigable</var>.
+   <li>Restart the initial navigation (before any redirects).
  </ol>
  <li>If <var>navigable</var>'s [=Critical-CH restart time=] is not 0:
  <ol>

--- a/index.bs
+++ b/index.bs
@@ -115,7 +115,7 @@ following specifications and proposals:
             same-origin or delegated-to cross-origin requests. It also makes sure
             hints are removed from not delegated-to cross-origin requests after
             redirections.
-     - Defines the `Critical-CH` response header, which servers may use to request a reload	
+     - Defines the `Critical-CH` response header, which servers may use to request a restart	
          to include critical Client Hints missing in the initial load.
      - Integrates those concepts with the [[!HTML]] and [[!FETCH]] specifications,
          by patching various concepts there.
@@ -185,19 +185,19 @@ If an [=url/origin=] is loaded and the server sets an `Accept-CH` header that
 lists hints not already in the current [=Accept-CH cache=] that means only
 subsiquent loads of that [=url/origin=] will include the hints. If it's
 critical that every load (including the first) has the requested Client Hints,
-then the server can set a `Critical-CH` header to request a reload. The
+then the server can set a `Critical-CH` header to request a restart. The
 `Critical-CH` header itself does not modify the [=Accept-CH cache=].
 
-A reload will only occur when a hint in the `Accept-CH` header is both *not in*
+A restart will only occur when a hint in the `Accept-CH` header is both *not in*
 the [=Accept-CH cache=] and *in* the `Critical-CH` header. If hints listed in
-the `Critical-CH` header are already in the [=Accept-CH cache=] no reload is
+the `Critical-CH` header are already in the [=Accept-CH cache=] no restart is
 needed as they were sent. If hints listed in the `Critical-CH` header are not
-in the `Accept-CH` header a reload would not result in the hints being included
+in the `Accept-CH` header a restart would not result in the hints being included
 anyway.
 
 There MAY be multiple `Critical-CH` headers per-response and <a>sf-lists</a> can be split across lines as long as each line contains at least one token.
 
-When asked if the user agent <dfn abstract-op>should reload page for critical client hints</dfn> given a |settingsObject| and |response|:
+When asked if the user agent <dfn abstract-op>should restart loading the page for critical client hints</dfn> given a |settingsObject| and |response|:
 
 <ol>
  <li>If |settingsObject| is a [=non-secure context=], abort these steps.
@@ -285,13 +285,13 @@ Navigation response {#navigation-response}
 
 At [=populating a session history entry=], in step 6 after substep 7 insert the following:
 <ol>
- <li>Let |shouldReloadForCriticalClientHints| be `false`.
- <li>If <var>navigable</var>'s [=time reloaded for Critical-CH=] is 0:
+ <li>Let |shouldRestartForCriticalClientHints| be `false`.
+ <li>If <var>navigable</var>'s [=Critical-CH restart time cache=] is 0:
  <ol>
-   <li>Let |shouldReloadForCriticalClientHints| be the result of running [$should reload page for critical client hints$] with the [=relevant settings object=] and |response|.
+   <li>Let |shouldRestartForCriticalClientHints| be the result of running [$should restart page for critical client hints$] with the [=relevant settings object=] and |response|.
  </ol>
  <li>Run [$create or override the cached client hints set$] with the [=relevant settings object=] and |response| as inputs.
- <li>If |shouldReloadForCriticalClientHints| then:
+ <li>If |shouldRestartForCriticalClientHints| then:
  <ol>
    <li>Set <var>navigable</var>'s [=Critical-CH restart time cache=] to the [=current high resolution time=].
    <li><a spec=HTML>reload</a> <var>navigable</var>.

--- a/index.bs
+++ b/index.bs
@@ -277,7 +277,7 @@ Navigable {#navigable}
 
 Add a new field to [=navigable=]:
 <ul>
- <li>A <dfn>time reloaded for `Critical-CH`</dfn> {{DOMHighResTimeStamp}}, initially 0.
+ <li>A <dfn>`Critical-CH` restart time</dfn> {{DOMHighResTimeStamp}}, initially 0.
 </ul>
 
 Navigation response {#navigation-response}
@@ -293,18 +293,18 @@ At [=populating a session history entry=], in step 6 after substep 7 insert the 
  <li>Run [$create or override the cached client hints set$] with the [=relevant settings object=] and |response| as inputs.
  <li>If |shouldReloadForCriticalClientHints| then:
  <ol>
-   <li>Set <var>navigable</var>'s [=time reloaded for Critical-CH=] to the [=current high resolution time=].
+   <li>Set <var>navigable</var>'s [=Critical-CH restart time=] to the [=current high resolution time=].
    <li><a spec=HTML>reload</a> <var>navigable</var>.
  </ol>
- <li>If <var>navigable</var>'s [=time reloaded for Critical-CH=] is not 0:
+ <li>If <var>navigable</var>'s [=Critical-CH restart time=] is not 0:
  <ol>
-    <li>Set <var>navigationParams</var>'s [=critical ch restart time=] to be <var>navigable</var>'s [=time reloaded for Critical-CH=].
+    <li>Set <var>navigationParams</var>'s [=Critical-CH restart time=] to be <var>navigable</var>'s [=Critical-CH restart time=].
  </ol>
 </ol>
 
 At [=navigation params=], append the following:
 <dl>
-<dt><dfn>critical ch restart time</dfn></dt>
+<dt><dfn>Critical-CH restart time</dfn></dt>
   <dd>a {{DOMHighResTimeStamp}} used for [=creating the navigation timing entry=] for the new <code>Document</code></dd>
 </dl>
 

--- a/index.bs
+++ b/index.bs
@@ -294,9 +294,18 @@ At [=populating a session history entry=], in step 6 after substep 7 insert the 
  <li>If |shouldReloadForCriticalClientHints| then:
  <ol>
    <li>Set <var>navigable</var>'s [=has reloaded for Critical-CH=] to `true`.
+   <li>Set <var>navigationParams</var>'s [=critical ch restart time=] to be the [=current high resolution time=].
    <li><a spec=HTML>reload</a> <var>navigable</var>.
  </ol>
 </ol>
+
+At [=navigation params=], append the following:
+<dl>
+<dt><dfn>critical ch restart time</dfn></dt>
+  <dd>a {{DOMHighResTimeStamp}} used for <span data-x="create the navigation timing
+   entry">creating the navigation timing entry</span> for the new <code>Document</code></dd>
+</dl>
+
 
 Service Worker initialization {#service-worker-init}
 -----------

--- a/index.bs
+++ b/index.bs
@@ -308,7 +308,7 @@ At [=populating a session history entry=], in step 6 after substep 7 insert the 
 
 At [=navigation params=], append the following:
 <dl>
-<dt>[=Critical-CH restart time=]</dt>
+<dt>`Critical-CH` restart time</dt>
   <dd>a {{DOMHighResTimeStamp}} used for [=creating the navigation timing entry=] for the new <code>Document</code>.
   This records the time the navigation was restarted to ensure required Client Hint headers will be sent.</dd>
 </dl>

--- a/index.bs
+++ b/index.bs
@@ -277,7 +277,7 @@ Navigable {#navigable}
 
 Add a new field to [=navigable=]:
 <ul>
- <li>A <dfn>has reloaded for `Critical-CH`</dfn> boolean, initially `false`.
+ <li>A <dfn>time reloaded for `Critical-CH`</dfn> {{DOMHighResTimeStamp}}, initially 0.
 </ul>
 
 Navigation response {#navigation-response}
@@ -286,16 +286,19 @@ Navigation response {#navigation-response}
 At [=populating a session history entry=], in step 6 after substep 7 insert the following:
 <ol>
  <li>Let |shouldReloadForCriticalClientHints| be `false`.
- <li>If <var>navigable</var>'s [=has reloaded for Critical-CH=] is `false`:
+ <li>If <var>navigable</var>'s [=time reloaded for Critical-CH=] is 0:
  <ol>
    <li>Let |shouldReloadForCriticalClientHints| be the result of running [$should reload page for critical client hints$] with the [=relevant settings object=] and |response|.
  </ol>
  <li>Run [$create or override the cached client hints set$] with the [=relevant settings object=] and |response| as inputs.
  <li>If |shouldReloadForCriticalClientHints| then:
  <ol>
-   <li>Set <var>navigable</var>'s [=has reloaded for Critical-CH=] to `true`.
-   <li>Set <var>navigationParams</var>'s [=critical ch restart time=] to be the [=current high resolution time=].
+   <li>Set <var>navigable</var>'s [=time reloaded for Critical-CH=] to the [=current high resolution time=].
    <li><a spec=HTML>reload</a> <var>navigable</var>.
+ </ol>
+ <li>If <var>navigable</var>'s [=time reloaded for Critical-CH=] is not 0:
+ <ol>
+    <li>Set <var>navigationParams</var>'s [=critical ch restart time=] to be <var>navigable</var>'s [=time reloaded for Critical-CH=].
  </ol>
 </ol>
 

--- a/index.bs
+++ b/index.bs
@@ -302,8 +302,7 @@ At [=populating a session history entry=], in step 6 after substep 7 insert the 
 At [=navigation params=], append the following:
 <dl>
 <dt><dfn>critical ch restart time</dfn></dt>
-  <dd>a {{DOMHighResTimeStamp}} used for <span data-x="create the navigation timing
-   entry">creating the navigation timing entry</span> for the new <code>Document</code></dd>
+  <dd>a {{DOMHighResTimeStamp}} used for [=creating the navigation timing entry=] for the new <code>Document</code></dd>
 </dl>
 
 


### PR DESCRIPTION
This is needed for https://github.com/w3c/navigation-timing/pull/188/.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/pull/153.html" title="Last updated on Jun 7, 2023, 1:27 PM UTC (edb2997)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/153/96a82df...edb2997.html" title="Last updated on Jun 7, 2023, 1:27 PM UTC (edb2997)">Diff</a>